### PR TITLE
Lookup function for SuiSelect options

### DIFF
--- a/components/search/search.service.ts
+++ b/components/search/search.service.ts
@@ -5,11 +5,11 @@ export type LookupFn<T, U> = (query:string, initial?:U) => Promise<T[]>
 type CachedArray<T> = { [query:string]:T[] };
 
 // T extends JavascriptObject so we can do a recursive search on the object.
-export class SearchService<T> {
+export class SearchService<T, U> {
     // Stores the available options.
     private _options:T[];
     // Converts a query string into an array of options. Must be a function returning a promise.
-    private _optionsLookup:LookupFn<T, any>;
+    private _optionsLookup:LookupFn<T, U>;
     // Field that options are searched & displayed on.
     private _optionsField:string;
     
@@ -29,11 +29,17 @@ export class SearchService<T> {
         return this._optionsLookup;
     }
 
-    public set optionsLookup(lookupFn:LookupFn<T, any>) {
+    public set optionsLookup(lookupFn:LookupFn<T, U>) {
         this._optionsLookup = lookupFn;
         // As before, cannot use local & remote options simultaneously.
         this._options = [];
         this.reset();
+    }
+
+    public get selectedLookup() {
+        if (this.optionsLookup && this.optionsLookup.length == 2) {
+            return this.optionsLookup;
+        }
     }
 
     public get optionsField() {
@@ -170,12 +176,9 @@ export class SearchService<T> {
 
     // Resets the search back to a pristine state.
     private reset() {
-        this._query = "";
         this._results = [];
-        if (this.allowEmptyQuery) {
-            this._results = this._options;
-        }
         this._resultsCache = {};
         this._isSearching = false;
+        this.updateQuery("");
     }
 }

--- a/components/search/search.ts
+++ b/components/search/search.ts
@@ -38,7 +38,7 @@ import {PositioningService, PositioningPlacement} from '../util/positioning.serv
 })
 export class SuiSearch<T> implements AfterViewInit {
     public dropdownService:DropdownService;
-    public searchService:SearchService<T>;
+    public searchService:SearchService<T, T>;
 
     @ViewChild(SuiDropdownMenu)
     private _menu:SuiDropdownMenu;
@@ -76,8 +76,8 @@ export class SuiSearch<T> implements AfterViewInit {
 
     // Sets local or remote options by determining whether a function is passed.
     @Input()
-    public set options(options:T[] | LookupFn<T, boolean>) {
-        if (typeof(options) == "function") {
+    public set options(options:T[] | LookupFn<T, T>) {
+        if (typeof options == "function") {
             this.searchService.optionsLookup = options;
             return;
         }
@@ -117,7 +117,7 @@ export class SuiSearch<T> implements AfterViewInit {
 
     constructor(private _element:ElementRef) {
         this.dropdownService = new DropdownService();
-        this.searchService = new SearchService<T>();
+        this.searchService = new SearchService<T, T>();
 
         this._searchClasses = true;
         this.hasIcon = true;

--- a/components/select/select-base.ts
+++ b/components/select/select-base.ts
@@ -10,7 +10,7 @@ import {Subscription} from 'rxjs';
 // We use generic type T to specify the type of the options we are working with, and U to specify the type of the property of the option used as the value.
 export abstract class SuiSelectBase<T, U> implements AfterContentInit {
     public dropdownService:DropdownService;
-    public searchService:SearchService<T>;
+    public searchService:SearchService<T, U>;
 
     @ViewChild(SuiDropdownMenu)
     protected _menu:SuiDropdownMenu;
@@ -70,17 +70,13 @@ export abstract class SuiSelectBase<T, U> implements AfterContentInit {
     }
 
     public set options(options:T[]) {
-        if (typeof (options) == "function") {
+        if (typeof options == "function") {
             this.searchService.optionsLookup = options;
-            let subscription = this.dropdownService.isOpenChange.subscribe((value:boolean) => {
-                if (value) {
-                    subscription.unsubscribe();
-                    this.updateQuery(this.query);
-                }
-            });
-            return;
         }
-        this.searchService.options = options;
+        else {
+            this.searchService.options = options;
+        }
+        
         this.optionsUpdateHook();
     }
 
@@ -140,7 +136,7 @@ export abstract class SuiSelectBase<T, U> implements AfterContentInit {
     constructor(private _element:ElementRef, private _renderer:Renderer) {
         this.dropdownService = new DropdownService();
         // We do want an empty query to return all results.
-        this.searchService = new SearchService<T>(true);
+        this.searchService = new SearchService<T, U>(true);
 
         this.isSearchable = false;
         this.noResultsMessage = "No results";

--- a/components/select/select.ts
+++ b/components/select/select.ts
@@ -90,14 +90,14 @@ export class SuiSelect<T, U> extends SuiSelectBase<T, U> {
                 this.selectedOption = this.findOption(this.options, value);
             }
             if (!this.selectedOption) {
-                let optionsLookup = this.searchService.optionsLookup;
-                if (optionsLookup && optionsLookup.length == 2) {
-                    // If there's a selected lookup function, query it
-                    optionsLookup(this.searchService.query, value)
-                        .then(results => {
-                            this.selectedOption = this.findOption(results, value)
+                if (this.searchService.selectedLookup) {
+                    // If the search service has a selected lookup function, make use of that to load the initial value.
+                    this.searchService.selectedLookup(undefined, value)
+                        .then(r => {
+                            this.selectedOption = this.findOption(r, value);
                             this.drawSelectedOption();
                         });
+                    return;
                 }
                 else {
                     // Otherwise, cache the written value for when options are set.

--- a/package.json
+++ b/package.json
@@ -46,11 +46,11 @@
     "zone.js": "^0.7.0"
   },
   "devDependencies": {
-    "@angular/cli": "1.0.0-rc.2",
-    "@angular/compiler": "^2.4.1",
-    "@angular/compiler-cli": "^2.4.1",
-    "@angular/platform-browser-dynamic": "^2.4.0",
-    "@angular/router": "^3.4.0",
+    "@angular/cli": "1.0.0",
+    "@angular/compiler": ">=2.4.1",
+    "@angular/compiler-cli": ">=2.4.1",
+    "@angular/platform-browser-dynamic": ">=2.4.0",
+    "@angular/router": ">=3.4.0",
     "@types/prismjs": "~1.4.18",
     "@types/protractor": "~4.0.0",
     "@types/requirejs": "~2.1.28",


### PR DESCRIPTION
I've gone through and made some of the changes myself:

* Moved the `isOpenChange` subscription to the search service (it now automatically searches when empty queries are allowed and it is using a remote lookup)
* Removed the `any` uses in the search service, and adding a `U` parameter (for the search component, it creates a search service using `<T, T>` since it doesn't support `valueField`

Could you merge these into your develop branch so the main PR on my repo updates please?